### PR TITLE
[M2M-17] We are not a cookie manager

### DIFF
--- a/src/Block/Widget/Flow.php
+++ b/src/Block/Widget/Flow.php
@@ -52,7 +52,6 @@ class Flow extends \Itonomy\Flowbox\Block\Base implements \Magento\Widget\Block\
                 'flow' => $flow,
                 'key' => $this->escapeHtml((string) $this->getData('key')),
                 'lazyload' => (bool) $this->getData('lazyload'),
-                'override_cookies' => $this->getData('override_cookies'),
                 'locale' => (string) $this->pageConfig->getElementAttribute('html', 'lang')
             ];
 

--- a/src/etc/widget.xml
+++ b/src/etc/widget.xml
@@ -44,18 +44,6 @@
                 </options>
             </parameter>
 
-            <parameter name="override_cookies" xsi:type="select" required="false" visible="true" sort_order="100">
-                <label translate="true">Override allow cookies tracking</label>
-                <options>
-                    <option name="yes" value="1">
-                        <label translate="true">Yes</label>
-                    </option>
-                    <option name="no" value="0" selected="true">
-                        <label translate="true">No</label>
-                    </option>
-                </options>
-            </parameter>
-
             <!-- Dynamic Product Flow -->
             <parameter name="product_id" xsi:type="text" required="false" visible="true" sort_order="30">
                 <label translate="true">Product Identifier</label>

--- a/src/view/frontend/web/js/checkout.js
+++ b/src/view/frontend/web/js/checkout.js
@@ -9,7 +9,6 @@ define([
     'ko',
     'jquery',
     'lib-flowbox-checkout',
-    'jquery/jquery.cookie',
     '!domReady'
 ], function(Component, _, ko, $, fb) {
     'use strict';
@@ -19,8 +18,6 @@ define([
     return Component.extend({
         defaults: {
             flowbox: {
-                allowCookies: false,
-                override_cookies: false
             }
         },
 
@@ -51,14 +48,6 @@ define([
             this._super(config);
 
             this.flowbox.products = _.values(config.flowbox.products)
-
-            var userAllowedSaveCookie = $.cookie('user_allowed_save_cookie')
-            if (!(_.isNull(userAllowedSaveCookie) || _.isUndefined(userAllowedSaveCookie))) {
-                this.flowbox.allowCookies = JSON.parse(userAllowedSaveCookie)["1"] === 1;
-            }
-            if (this.flowbox.override_cookies){
-                this.flowbox.allowCookies = 1;
-            }
 
             var interval = setInterval(function() {
                 if (_.isObject(window.flowboxCheckout) && _.isFunction(window.flowboxCheckout.checkout)) {

--- a/src/view/frontend/web/js/flowbox.js
+++ b/src/view/frontend/web/js/flowbox.js
@@ -9,7 +9,6 @@ define([
     'ko',
     'jquery',
     'lib-flowbox',
-    'jquery/jquery.cookie',
     '!domReady'
 ], function(Component, _, ko, $, fb) {
     'use strict';
@@ -21,19 +20,16 @@ define([
         'tags',
         'tagsOperator',
         'productId',
-        'allowCookies',
         'lazyload'
     ];
 
     return Component.extend({
         defaults: {
             flowbox: {
-                allowCookies: false,
                 lazyload: true,
                 showTagBar: false,
                 tags: [],
                 debug: false,
-                override_cookies: false
             },
             template: {
                 name: "Itonomy_Flowbox/flowbox",
@@ -70,14 +66,6 @@ define([
             }
 
             this._super(config);
-
-            var userAllowedSaveCookie = $.cookie('user_allowed_save_cookie')
-            if (!(_.isNull(userAllowedSaveCookie) || _.isUndefined(userAllowedSaveCookie))) {
-                this.flowbox.allowCookies = JSON.parse(userAllowedSaveCookie)["1"] === 1;
-            }
-            if (this.flowbox.override_cookies){
-                this.flowbox = _.omit(this.flowbox, 'allowCookies')
-            }
 
             if (config.flowbox.showTagBar) {
                 _.each(this.flowbox.tags, function(tag) {


### PR DESCRIPTION
@andyschofieuk awaiting feedback from Arjan, otherwise I hereby remove all cookie management code. It's not this module's responsibility. The module does not set it's own cookies and for the cookies coming through the loaded JS we should delegate the responsibility to a cookie management module. This fixes the many cookie issues we experience right now, where the flowbox cookies have been whitelisted but still get blocked.