### PR TITLE
Fix for setting locale

### DIFF
--- a/Block/Widget/Flow.php
+++ b/Block/Widget/Flow.php
@@ -15,6 +15,8 @@ class Flow extends \Itonomy\Flowbox\Block\Base implements \Magento\Widget\Block\
 
     private \Magento\Framework\Api\SearchCriteriaBuilder $searchCriteriaBuilder;
 
+    private \Magento\Framework\Locale\Resolver $store;
+
     /**
      * Flow constructor.
      * @param \Magento\Framework\View\Element\Template\Context $context
@@ -22,6 +24,7 @@ class Flow extends \Itonomy\Flowbox\Block\Base implements \Magento\Widget\Block\
      * @param \Magento\Framework\Api\SearchCriteriaBuilder $searchCriteriaBuilder
      * @param \Magento\Cookie\Helper\Cookie $cookie
      * @param \Magento\Framework\Encryption\EncryptorInterface $encryptor
+     * @param \Magento\Framework\Encryption\EncryptorInterface $store
      * @param array $data
      */
     public function __construct(
@@ -30,11 +33,13 @@ class Flow extends \Itonomy\Flowbox\Block\Base implements \Magento\Widget\Block\
         \Magento\Framework\Api\SearchCriteriaBuilder $searchCriteriaBuilder,
         \Magento\Cookie\Helper\Cookie $cookie,
         \Magento\Framework\Encryption\EncryptorInterface $encryptor,
+        \Magento\Framework\Locale\Resolver $store,
         array $data = []
     ) {
         parent::__construct($context, $cookie, $encryptor, $data);
         $this->productRepository = $productRepository;
         $this->searchCriteriaBuilder = $searchCriteriaBuilder;
+        $this->_store = $store;
     }
 
     /**
@@ -50,7 +55,7 @@ class Flow extends \Itonomy\Flowbox\Block\Base implements \Magento\Widget\Block\
                 'flow' => $flow,
                 'key' => $this->escapeHtml((string) $this->getData('key')),
                 'lazyload' => (bool) $this->getData('lazyload'),
-                'locale' => (string) $this->pageConfig->getElementAttribute('html', 'lang')
+                'locale' => (string) $this->getData('locale') ?: $this->_store->getLocale()
             ];
 
             if ($flow === static::FLOW_TYPE_DYNAMIC_PRODUCT) {

--- a/etc/widget.xml
+++ b/etc/widget.xml
@@ -32,6 +32,14 @@
                 <description translate="true">Visit <![CDATA[<a href="https://app.getflowbox.com/login">flowbox</a>]]> to access your flows.</description>
             </parameter>
 
+            <parameter name="locale" xsi:type="text" required="false" visible="true" sort_order="25">
+                <label translate="true">Locale</label>
+                <description translate="true"><![CDATA[
+                    If left empty the <a href="https://docs.magento.com/user-guide/configuration/general/general.html#locale-options">Magento store locale</a> will be used. <br />
+                    Visit <a href="https://help.getflowbox.com/en/articles/4485750-changing-the-language-region-of-your-flow#our-supported-locales">here</a> to see a list of supported locales.
+                ]]></description>
+            </parameter>
+
             <parameter name="lazyload" xsi:type="select" required="false" visible="true" sort_order="99">
                 <label translate="true">Enable Lazy Loading</label>
                 <options>


### PR DESCRIPTION
Hello, thank you for the module, it works very nicely. I have a small improvement I'd like to share.

#### The Issue
The locale is currently set by the value from the HTML tag's `lang` attribute.
https://github.com/Itonomy/module-flowbox/blob/075ee836544f485e28e8743d3282c976202f4958/Block/Widget/Flow.php#L53

This includes the language, e.g. `en`, but not the region which makes it invalid for Flowbox.
https://help.getflowbox.com/en/articles/4485750-changing-the-language-region-of-your-flow#our-supported-locales.

<img src="https://user-images.githubusercontent.com/2452991/178005300-1d2e7a0e-c383-4ccd-a3c2-cfeef6ac5eab.png" data-canonical-src="https://user-images.githubusercontent.com/2452991/178005300-1d2e7a0e-c383-4ccd-a3c2-cfeef6ac5eab.png" width="400" />

#### The Solution
The changes here fixes this to get the locale from the widget options, or if a locale is not set in the widget options, it will be gotten from the [Magento store locale](https://docs.magento.com/user-guide/configuration/general/general.html#locale-options).

**New Widget Option:**

<img src="https://user-images.githubusercontent.com/2452991/178004086-fa4e4b4b-a689-4e58-a9b3-4639c06050f4.png" data-canonical-src="https://user-images.githubusercontent.com/2452991/178004086-fa4e4b4b-a689-4e58-a9b3-4639c06050f4.png" width="400" />


[**Magento store locale**:](https://docs.magento.com/user-guide/configuration/general/general.html#locale-options)

<img src="https://user-images.githubusercontent.com/2452991/178004217-37953973-f9cf-4cb0-b475-05193f02bdf8.png" data-canonical-src="https://user-images.githubusercontent.com/2452991/178004217-37953973-f9cf-4cb0-b475-05193f02bdf8.png" width="400" />



The reason for having an option in the widget, is that some Magento stores do not have their locale configured correctly.